### PR TITLE
chore(package.json): Manually bump version to 1.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-ts-open-weather-map",
-  "version": "1.1.0",
+  "version": "1.2.1",
   "description": "Node.js typescript OpenWeatherMap api wrapper",
   "license": "MIT",
   "repository": "https://github.com/ovaar/node-ts-open-weather-map",


### PR DESCRIPTION
Semantic version is off because the version in package.json was somehow still 1.1.0